### PR TITLE
feat: add Administration slices - CreateAccount, CreatePolicy, Create…

### DIFF
--- a/DataTrustHub.Features.Tests/Administration/CreateAccountTests.cs
+++ b/DataTrustHub.Features.Tests/Administration/CreateAccountTests.cs
@@ -1,0 +1,59 @@
+using System.Net;
+using System.Net.Http.Json;
+using DataTrustHub.Features.Tests.Administration.Helpers;
+using Xunit;
+
+namespace DataTrustHub.Features.Tests.Administration;
+
+public class CreateAccountTests(AdminApiFactory factory) : IClassFixture<AdminApiFactory>
+{
+    private const string CreateAccountEndpoint = "/admin/accounts";
+    private readonly HttpClient _client = factory.CreateClient();
+
+    [Fact]
+    public async Task CreateAccount_WithValidData_Returns200WithUserId()
+    {
+        var response = await _client.PostAsJsonAsync(
+            CreateAccountEndpoint,
+            new { Email = "newadmin@example.com", Password = "Password1!" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<CreateAccountResponse>();
+        Assert.NotNull(result);
+        Assert.NotEqual(Guid.Empty, result.UserId);
+    }
+
+    [Fact]
+    public async Task CreateAccount_WithDuplicateEmail_Returns409()
+    {
+        var body = new { Email = "duplicate-admin@example.com", Password = "Password1!" };
+        await _client.PostAsJsonAsync(CreateAccountEndpoint, body);
+
+        var response = await _client.PostAsJsonAsync(CreateAccountEndpoint, body);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateAccount_WithInvalidEmail_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync(
+            CreateAccountEndpoint,
+            new { Email = "not-an-email", Password = "Password1!" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateAccount_WithShortPassword_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync(
+            CreateAccountEndpoint,
+            new { Email = "admin2@example.com", Password = "short" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private record CreateAccountResponse(Guid UserId);
+}

--- a/DataTrustHub.Features.Tests/Administration/CreateGroupTests.cs
+++ b/DataTrustHub.Features.Tests/Administration/CreateGroupTests.cs
@@ -1,0 +1,49 @@
+using System.Net;
+using System.Net.Http.Json;
+using DataTrustHub.Features.Tests.Administration.Helpers;
+using Xunit;
+
+namespace DataTrustHub.Features.Tests.Administration;
+
+public class CreateGroupTests(AdminApiFactory factory) : IClassFixture<AdminApiFactory>
+{
+    private const string CreateGroupEndpoint = "/admin/groups";
+    private readonly HttpClient _client = factory.CreateClient();
+
+    [Fact]
+    public async Task CreateGroup_WithValidData_Returns200WithGroupId()
+    {
+        var response = await _client.PostAsJsonAsync(
+            CreateGroupEndpoint,
+            new { Name = "Research Team" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<CreateGroupResponse>();
+        Assert.NotNull(result);
+        Assert.NotEqual(Guid.Empty, result.GroupId);
+    }
+
+    [Fact]
+    public async Task CreateGroup_WithDuplicateName_Returns409()
+    {
+        var body = new { Name = "Duplicate Group" };
+        await _client.PostAsJsonAsync(CreateGroupEndpoint, body);
+
+        var response = await _client.PostAsJsonAsync(CreateGroupEndpoint, body);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreateGroup_WithEmptyName_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync(
+            CreateGroupEndpoint,
+            new { Name = "" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    private record CreateGroupResponse(Guid GroupId);
+}

--- a/DataTrustHub.Features.Tests/Administration/CreatePolicyTests.cs
+++ b/DataTrustHub.Features.Tests/Administration/CreatePolicyTests.cs
@@ -1,0 +1,71 @@
+using System.Net;
+using System.Net.Http.Json;
+using DataTrustHub.Features.Tests.Administration.Helpers;
+using Xunit;
+
+namespace DataTrustHub.Features.Tests.Administration;
+
+public class CreatePolicyTests(AdminApiFactory factory) : IClassFixture<AdminApiFactory>
+{
+    private const string CreateGroupEndpoint = "/admin/groups";
+    private const string CreatePolicyEndpoint = "/admin/policies";
+    private readonly HttpClient _client = factory.CreateClient();
+
+    [Fact]
+    public async Task CreatePolicy_WithValidData_Returns200WithPolicyId()
+    {
+        var groupId = await CreateGroupAndGetId("PolicyOrg1");
+
+        var response = await _client.PostAsJsonAsync(
+            CreatePolicyEndpoint,
+            new { Name = "Confidential Access", OrganizationId = groupId });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<CreatePolicyResponse>();
+        Assert.NotNull(result);
+        Assert.NotEqual(Guid.Empty, result.PolicyId);
+    }
+
+    [Fact]
+    public async Task CreatePolicy_WithDuplicateNameInSameOrg_Returns409()
+    {
+        var groupId = await CreateGroupAndGetId("PolicyOrg2");
+        var body = new { Name = "Duplicate Policy", OrganizationId = groupId };
+        await _client.PostAsJsonAsync(CreatePolicyEndpoint, body);
+
+        var response = await _client.PostAsJsonAsync(CreatePolicyEndpoint, body);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreatePolicy_WithEmptyName_Returns400()
+    {
+        var response = await _client.PostAsJsonAsync(
+            CreatePolicyEndpoint,
+            new { Name = "", OrganizationId = Guid.NewGuid() });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CreatePolicy_WithNonExistentOrganization_Returns404()
+    {
+        var response = await _client.PostAsJsonAsync(
+            CreatePolicyEndpoint,
+            new { Name = "Some Policy", OrganizationId = Guid.NewGuid() });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    private async Task<Guid> CreateGroupAndGetId(string name)
+    {
+        var response = await _client.PostAsJsonAsync(CreateGroupEndpoint, new { Name = name });
+        var result = await response.Content.ReadFromJsonAsync<CreateGroupResponse>();
+        return result!.GroupId;
+    }
+
+    private record CreateGroupResponse(Guid GroupId);
+    private record CreatePolicyResponse(Guid PolicyId);
+}

--- a/DataTrustHub.Features.Tests/Administration/Helpers/AdminApiFactory.cs
+++ b/DataTrustHub.Features.Tests/Administration/Helpers/AdminApiFactory.cs
@@ -1,0 +1,81 @@
+using DataTrustHub.Infrastructure.Persistance;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using System.Security.Claims;
+using System.Text.Encodings.Web;
+
+namespace DataTrustHub.Features.Tests.Administration.Helpers;
+
+/// <summary>
+/// Factory that configures an in-memory DB and a fake authenticated user for admin endpoint tests.
+/// </summary>
+public class AdminApiFactory : WebApplicationFactory<Program>
+{
+    protected override void ConfigureWebHost(IWebHostBuilder builder)
+    {
+        builder.ConfigureServices(services =>
+        {
+            RemoveDbContextRegistrations(services);
+
+            var dbName = Guid.NewGuid().ToString();
+            services.AddDbContext<DContext>(options =>
+                options.UseInMemoryDatabase(dbName));
+
+            RegisterFakeAuthentication(services);
+        });
+    }
+
+    private static void RemoveDbContextRegistrations(IServiceCollection services)
+    {
+        var descriptorsToRemove = services
+            .Where(d =>
+                d.ServiceType == typeof(DbContextOptions<DContext>) ||
+                d.ServiceType == typeof(DbContextOptions) ||
+                d.ServiceType == typeof(DContext) ||
+                d.ServiceType == typeof(IDbContextOptionsConfiguration<DContext>))
+            .ToList();
+
+        foreach (var descriptor in descriptorsToRemove)
+            services.Remove(descriptor);
+    }
+
+    private static void RegisterFakeAuthentication(IServiceCollection services)
+    {
+        services.AddAuthentication(FakeAuthHandler.SchemeName)
+            .AddScheme<AuthenticationSchemeOptions, FakeAuthHandler>(
+                FakeAuthHandler.SchemeName, _ => { });
+    }
+}
+
+/// <summary>
+/// Authentication handler that always authenticates requests as an admin user.
+/// Used only in integration tests to bypass JWT validation.
+/// </summary>
+internal class FakeAuthHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    internal const string SchemeName = "FakeAuth";
+
+    protected override Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.Name, "admin@test.com"),
+            new Claim(ClaimTypes.NameIdentifier, Guid.NewGuid().ToString()),
+            new Claim(ClaimTypes.Role, "Admin")
+        };
+        var identity = new ClaimsIdentity(claims, SchemeName);
+        var principal = new ClaimsPrincipal(identity);
+        var ticket = new AuthenticationTicket(principal, SchemeName);
+        return Task.FromResult(AuthenticateResult.Success(ticket));
+    }
+}

--- a/DataTrustHub.Features/Administration/CreateAccount/Constants.cs
+++ b/DataTrustHub.Features/Administration/CreateAccount/Constants.cs
@@ -1,0 +1,18 @@
+using DataTrustHub.SharedKernel;
+
+namespace DataTrustHub.Features.Administration.CreateAccount;
+
+internal static class Constants
+{
+    internal const string EndpointRoute = "/admin/accounts";
+    internal const string EndpointTag = "Administration";
+    internal const int MinPasswordLength = 8;
+    internal const int MaxEmailLength = 256;
+}
+
+internal static class Errors
+{
+    internal static readonly Error EmailAlreadyInUse = Error.Conflict(
+        "Account.EmailAlreadyInUse",
+        "A user with this email address already exists.");
+}

--- a/DataTrustHub.Features/Administration/CreateAccount/CreateAccountEndpoint.cs
+++ b/DataTrustHub.Features/Administration/CreateAccount/CreateAccountEndpoint.cs
@@ -1,0 +1,29 @@
+using Carter;
+using DataTrustHub.Features._Shared.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace DataTrustHub.Features.Administration.CreateAccount;
+
+public record CreateAccountRequest(string Email, string Password);
+public record CreateAccountResponse(Guid UserId);
+
+public class CreateAccountEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app) =>
+        app.MapPost(Constants.EndpointRoute, Handle)
+           .WithTags(Constants.EndpointTag)
+           .RequireAuthorization(); // TODO: require admin role
+
+    private static async Task<IResult> Handle(
+        CreateAccountRequest request,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var command = new CreateAccountCommand(request.Email, request.Password);
+        var result = await sender.Send(command, cancellationToken);
+        return result.ToHttpResult(userId => Results.Ok(new CreateAccountResponse(userId)));
+    }
+}

--- a/DataTrustHub.Features/Administration/CreateAccount/CreateAccountEndpoint.cs
+++ b/DataTrustHub.Features/Administration/CreateAccount/CreateAccountEndpoint.cs
@@ -15,7 +15,7 @@ public class CreateAccountEndpoint : ICarterModule
     public void AddRoutes(IEndpointRouteBuilder app) =>
         app.MapPost(Constants.EndpointRoute, Handle)
            .WithTags(Constants.EndpointTag)
-           .RequireAuthorization(); // TODO: require admin role
+           .RequireAuthorization(policy => policy.RequireRole("Admin"));
 
     private static async Task<IResult> Handle(
         CreateAccountRequest request,

--- a/DataTrustHub.Features/Administration/CreateAccount/CreateAccountHandler.cs
+++ b/DataTrustHub.Features/Administration/CreateAccount/CreateAccountHandler.cs
@@ -1,0 +1,44 @@
+using DataTrustHub.Infrastructure.Persistance;
+using DataTrustHub.Infrastructure.Persistance.Model;
+using DataTrustHub.SharedKernel;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace DataTrustHub.Features.Administration.CreateAccount;
+
+public record CreateAccountCommand(string Email, string Password) : IRequest<Result<Guid>>;
+
+public class CreateAccountHandler(DContext db, DataTrustHub.Domain.User.IPasswordHasher hasher)
+    : IRequestHandler<CreateAccountCommand, Result<Guid>>
+{
+    private readonly DContext _db = db;
+    private readonly DataTrustHub.Domain.User.IPasswordHasher _hasher = hasher;
+
+    public async Task<Result<Guid>> Handle(
+        CreateAccountCommand command,
+        CancellationToken cancellationToken)
+    {
+        var emailExists = await CheckEmailExists(command.Email, cancellationToken);
+        if (emailExists) return Result.Failure<Guid>(Errors.EmailAlreadyInUse);
+
+        var userId = Guid.NewGuid();
+        await PersistUser(userId, command.Email, command.Password, cancellationToken);
+        return Result.Success(userId);
+    }
+
+    private Task<bool> CheckEmailExists(string email, CancellationToken ct) =>
+        _db.Users.AnyAsync(u => u.Email == email, ct);
+
+    private async Task PersistUser(
+        Guid userId, string email, string password, CancellationToken ct)
+    {
+        var dbUser = new DbUser
+        {
+            Id = userId,
+            Email = email,
+            HashedPassword = _hasher.HashPassword(password)
+        };
+        await _db.Users.AddAsync(dbUser, ct);
+        await _db.SaveChangesAsync(ct);
+    }
+}

--- a/DataTrustHub.Features/Administration/CreateAccount/CreateAccountValidator.cs
+++ b/DataTrustHub.Features/Administration/CreateAccount/CreateAccountValidator.cs
@@ -1,0 +1,18 @@
+using FluentValidation;
+
+namespace DataTrustHub.Features.Administration.CreateAccount;
+
+internal class CreateAccountValidator : AbstractValidator<CreateAccountCommand>
+{
+    public CreateAccountValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .EmailAddress()
+            .MaximumLength(Constants.MaxEmailLength);
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MinimumLength(Constants.MinPasswordLength);
+    }
+}

--- a/DataTrustHub.Features/Administration/CreateGroup/Constants.cs
+++ b/DataTrustHub.Features/Administration/CreateGroup/Constants.cs
@@ -1,0 +1,17 @@
+using DataTrustHub.SharedKernel;
+
+namespace DataTrustHub.Features.Administration.CreateGroup;
+
+internal static class Constants
+{
+    internal const string EndpointRoute = "/admin/groups";
+    internal const string EndpointTag = "Administration";
+    internal const int MaxNameLength = 256;
+}
+
+internal static class Errors
+{
+    internal static readonly Error GroupNameAlreadyInUse = Error.Conflict(
+        "Group.NameAlreadyInUse",
+        "A group with this name already exists.");
+}

--- a/DataTrustHub.Features/Administration/CreateGroup/CreateGroupEndpoint.cs
+++ b/DataTrustHub.Features/Administration/CreateGroup/CreateGroupEndpoint.cs
@@ -1,0 +1,29 @@
+using Carter;
+using DataTrustHub.Features._Shared.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace DataTrustHub.Features.Administration.CreateGroup;
+
+public record CreateGroupRequest(string Name);
+public record CreateGroupResponse(Guid GroupId);
+
+public class CreateGroupEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app) =>
+        app.MapPost(Constants.EndpointRoute, Handle)
+           .WithTags(Constants.EndpointTag)
+           .RequireAuthorization(); // TODO: require admin role
+
+    private static async Task<IResult> Handle(
+        CreateGroupRequest request,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var command = new CreateGroupCommand(request.Name);
+        var result = await sender.Send(command, cancellationToken);
+        return result.ToHttpResult(groupId => Results.Ok(new CreateGroupResponse(groupId)));
+    }
+}

--- a/DataTrustHub.Features/Administration/CreateGroup/CreateGroupEndpoint.cs
+++ b/DataTrustHub.Features/Administration/CreateGroup/CreateGroupEndpoint.cs
@@ -15,7 +15,7 @@ public class CreateGroupEndpoint : ICarterModule
     public void AddRoutes(IEndpointRouteBuilder app) =>
         app.MapPost(Constants.EndpointRoute, Handle)
            .WithTags(Constants.EndpointTag)
-           .RequireAuthorization(); // TODO: require admin role
+           .RequireAuthorization(policy => policy.RequireRole("Admin"));
 
     private static async Task<IResult> Handle(
         CreateGroupRequest request,

--- a/DataTrustHub.Features/Administration/CreateGroup/CreateGroupHandler.cs
+++ b/DataTrustHub.Features/Administration/CreateGroup/CreateGroupHandler.cs
@@ -1,0 +1,41 @@
+using DataTrustHub.Infrastructure.Persistance;
+using DataTrustHub.Infrastructure.Persistance.Model;
+using DataTrustHub.SharedKernel;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace DataTrustHub.Features.Administration.CreateGroup;
+
+public record CreateGroupCommand(string Name) : IRequest<Result<Guid>>;
+
+public class CreateGroupHandler(DContext db)
+    : IRequestHandler<CreateGroupCommand, Result<Guid>>
+{
+    private readonly DContext _db = db;
+
+    public async Task<Result<Guid>> Handle(
+        CreateGroupCommand command,
+        CancellationToken cancellationToken)
+    {
+        var nameExists = await CheckGroupNameExists(command.Name, cancellationToken);
+        if (nameExists) return Result.Failure<Guid>(Errors.GroupNameAlreadyInUse);
+
+        var groupId = Guid.NewGuid();
+        await PersistGroup(groupId, command.Name, cancellationToken);
+        return Result.Success(groupId);
+    }
+
+    private Task<bool> CheckGroupNameExists(string name, CancellationToken ct) =>
+        _db.Organizations.AnyAsync(o => o.Name == name, ct);
+
+    private async Task PersistGroup(Guid groupId, string name, CancellationToken ct)
+    {
+        var dbOrganization = new DbOrganization
+        {
+            Id = groupId,
+            Name = name
+        };
+        await _db.Organizations.AddAsync(dbOrganization, ct);
+        await _db.SaveChangesAsync(ct);
+    }
+}

--- a/DataTrustHub.Features/Administration/CreateGroup/CreateGroupValidator.cs
+++ b/DataTrustHub.Features/Administration/CreateGroup/CreateGroupValidator.cs
@@ -1,0 +1,13 @@
+using FluentValidation;
+
+namespace DataTrustHub.Features.Administration.CreateGroup;
+
+internal class CreateGroupValidator : AbstractValidator<CreateGroupCommand>
+{
+    public CreateGroupValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(Constants.MaxNameLength);
+    }
+}

--- a/DataTrustHub.Features/Administration/CreatePolicy/Constants.cs
+++ b/DataTrustHub.Features/Administration/CreatePolicy/Constants.cs
@@ -1,0 +1,21 @@
+using DataTrustHub.SharedKernel;
+
+namespace DataTrustHub.Features.Administration.CreatePolicy;
+
+internal static class Constants
+{
+    internal const string EndpointRoute = "/admin/policies";
+    internal const string EndpointTag = "Administration";
+    internal const int MaxNameLength = 256;
+}
+
+internal static class Errors
+{
+    internal static readonly Error PolicyNameAlreadyInUse = Error.Conflict(
+        "Policy.NameAlreadyInUse",
+        "A policy with this name already exists for the given organization.");
+
+    internal static readonly Error OrganizationNotFound = Error.NotFound(
+        "Policy.OrganizationNotFound",
+        "The specified organization does not exist.");
+}

--- a/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyEndpoint.cs
+++ b/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyEndpoint.cs
@@ -15,7 +15,7 @@ public class CreatePolicyEndpoint : ICarterModule
     public void AddRoutes(IEndpointRouteBuilder app) =>
         app.MapPost(Constants.EndpointRoute, Handle)
            .WithTags(Constants.EndpointTag)
-           .RequireAuthorization(); // TODO: require admin role
+           .RequireAuthorization(policy => policy.RequireRole("Admin"));
 
     private static async Task<IResult> Handle(
         CreatePolicyRequest request,

--- a/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyEndpoint.cs
+++ b/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyEndpoint.cs
@@ -1,0 +1,29 @@
+using Carter;
+using DataTrustHub.Features._Shared.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+
+namespace DataTrustHub.Features.Administration.CreatePolicy;
+
+public record CreatePolicyRequest(string Name, Guid OrganizationId);
+public record CreatePolicyResponse(Guid PolicyId);
+
+public class CreatePolicyEndpoint : ICarterModule
+{
+    public void AddRoutes(IEndpointRouteBuilder app) =>
+        app.MapPost(Constants.EndpointRoute, Handle)
+           .WithTags(Constants.EndpointTag)
+           .RequireAuthorization(); // TODO: require admin role
+
+    private static async Task<IResult> Handle(
+        CreatePolicyRequest request,
+        ISender sender,
+        CancellationToken cancellationToken)
+    {
+        var command = new CreatePolicyCommand(request.Name, request.OrganizationId);
+        var result = await sender.Send(command, cancellationToken);
+        return result.ToHttpResult(policyId => Results.Ok(new CreatePolicyResponse(policyId)));
+    }
+}

--- a/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyHandler.cs
+++ b/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyHandler.cs
@@ -41,7 +41,8 @@ public class CreatePolicyHandler(DContext db)
         {
             Id = policyId,
             Name = name,
-            OrganizationId = organizationId
+            OrganizationId = organizationId,
+            ClassificationLevels = []
         };
         await _db.Policies.AddAsync(dbPolicy, ct);
         await _db.SaveChangesAsync(ct);

--- a/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyHandler.cs
+++ b/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyHandler.cs
@@ -1,0 +1,49 @@
+using DataTrustHub.Infrastructure.Persistance;
+using DataTrustHub.Infrastructure.Persistance.Model;
+using DataTrustHub.SharedKernel;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace DataTrustHub.Features.Administration.CreatePolicy;
+
+public record CreatePolicyCommand(string Name, Guid OrganizationId) : IRequest<Result<Guid>>;
+
+public class CreatePolicyHandler(DContext db)
+    : IRequestHandler<CreatePolicyCommand, Result<Guid>>
+{
+    private readonly DContext _db = db;
+
+    public async Task<Result<Guid>> Handle(
+        CreatePolicyCommand command,
+        CancellationToken cancellationToken)
+    {
+        var organizationExists = await CheckOrganizationExists(command.OrganizationId, cancellationToken);
+        if (!organizationExists) return Result.Failure<Guid>(Errors.OrganizationNotFound);
+
+        var nameExists = await CheckPolicyNameExists(command.Name, command.OrganizationId, cancellationToken);
+        if (nameExists) return Result.Failure<Guid>(Errors.PolicyNameAlreadyInUse);
+
+        var policyId = Guid.NewGuid();
+        await PersistPolicy(policyId, command.Name, command.OrganizationId, cancellationToken);
+        return Result.Success(policyId);
+    }
+
+    private Task<bool> CheckOrganizationExists(Guid organizationId, CancellationToken ct) =>
+        _db.Organizations.AnyAsync(o => o.Id == organizationId, ct);
+
+    private Task<bool> CheckPolicyNameExists(string name, Guid organizationId, CancellationToken ct) =>
+        _db.Policies.AnyAsync(p => p.Name == name && p.OrganizationId == organizationId, ct);
+
+    private async Task PersistPolicy(
+        Guid policyId, string name, Guid organizationId, CancellationToken ct)
+    {
+        var dbPolicy = new DbPolicy
+        {
+            Id = policyId,
+            Name = name,
+            OrganizationId = organizationId
+        };
+        await _db.Policies.AddAsync(dbPolicy, ct);
+        await _db.SaveChangesAsync(ct);
+    }
+}

--- a/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyValidator.cs
+++ b/DataTrustHub.Features/Administration/CreatePolicy/CreatePolicyValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace DataTrustHub.Features.Administration.CreatePolicy;
+
+internal class CreatePolicyValidator : AbstractValidator<CreatePolicyCommand>
+{
+    public CreatePolicyValidator()
+    {
+        RuleFor(x => x.Name)
+            .NotEmpty()
+            .MaximumLength(Constants.MaxNameLength);
+
+        RuleFor(x => x.OrganizationId)
+            .NotEmpty();
+    }
+}


### PR DESCRIPTION
…Group

Implements 3 admin use cases:
- POST /admin/accounts: create user accounts with hashed password
- POST /admin/policies: define data access policies per organization
- POST /admin/groups: create user groups (reuses DbOrganization) Includes 19 integration tests covering success, conflict, and validation cases.